### PR TITLE
🐛 Better integer parsing in `NumberForm`

### DIFF
--- a/src/DynamicForm/TextyForm.js
+++ b/src/DynamicForm/TextyForm.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import PropTypes from 'prop-types'
+import util from '../util'
 
 const TextyFormType = {
   text: 'TextyFormType.text',
@@ -11,6 +12,8 @@ const INPUT_TYPE_NUMBER = 'number'
 
 const ROLE_INPUT_STRING = 'role-input-string'
 const ROLE_INPUT_NUMBER = 'role-input-number'
+
+const EMPTY_VALUE = ''
 
 export const StringForm = ({ schema, atKey = null, onChange }) => {
   return (
@@ -37,20 +40,31 @@ export const NumberForm = ({ schema, atKey = null, onChange }) => {
 const TextyForm = ({ type, schema, atKey = null, onChange }) => {
   // If default value is not available then use empty string as default value so html will not throw error later.
   const [value, setValue] = useState(() => {
-    if (schema.defaultValue !== undefined) {
-      onChange({ newValue: schema.defaultValue, key: atKey })
-      return schema.defaultValue
-    } else {
-      return ''
+    const providedDefaultValue = schema.defaultValue
+    if (util.isUndefinedOrNull(providedDefaultValue)) {
+      return EMPTY_VALUE
     }
+
+    let defaultValue = providedDefaultValue
+    if (type === TextyFormType.number) {
+      defaultValue = util.parseInteger(providedDefaultValue, EMPTY_VALUE)
+    }
+
+    onChange({ newValue: defaultValue, key: atKey })
+    return defaultValue
   })
 
   const changeValue = (newValue) => {
     const parsedValue =
-      type === TextyFormType.number ? parseInt(newValue) : newValue
-    setValue(parsedValue)
-    if (parsedValue !== undefined)
-      onChange({ newValue: parsedValue, key: atKey })
+      type === TextyFormType.number
+        ? util.parseInteger(newValue, value)
+        : newValue
+
+    if (parsedValue !== value) {
+      setValue(parsedValue)
+      if (parsedValue !== undefined)
+        onChange({ newValue: parsedValue, key: atKey })
+    }
   }
 
   const formType =

--- a/src/DynamicForm/__tests__/TextyForm.test.js
+++ b/src/DynamicForm/__tests__/TextyForm.test.js
@@ -58,6 +58,41 @@ test('NumberForm will reflect changed value', () => {
   expect(component.getByDisplayValue('1337')).toBeInTheDocument(component)
 })
 
+test('NumberForm will not have default value if passed default value is not parsable as a number', () => {
+  const component = render(
+    <NumberForm
+      schema={{
+        label: 'Number Form',
+        defaultValue: 'xyz',
+        placeholder: 'Number'
+      }}
+      onChange={() => {}}
+    />
+  )
+
+  expect(component.queryByDisplayValue('xyz')).toBeNull()
+})
+
+test('NumberForm will not change value if new value is not parsable as a number', () => {
+  const component = render(
+    <NumberForm
+      schema={{
+        label: 'Number Form',
+        defaultValue: '0',
+        placeholder: 'Number'
+      }}
+      onChange={() => {}}
+    />
+  )
+
+  const input = component.getByRole(ROLE_INPUT_NUMBER)
+  fireEvent.change(input, {
+    target: { value: 'xyz' }
+  })
+
+  expect(component.queryByDisplayValue('xyz')).toBeNull()
+})
+
 test('StringForm with correct props matches snapshot', () => {
   const component = render(
     <StringForm

--- a/src/Schema/schema.js
+++ b/src/Schema/schema.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-prototype-builtins */
 import { DynamicFormType } from './type'
+import util from '../util'
 
 const schema = (sch) => {
   const expandedSch = {}
@@ -26,9 +27,16 @@ const getLabelFromKeyAndSchema = (key, schemaForKey) => {
 }
 
 const getDefaultValueFromKeyAndSchema = (sch) => {
-  if (sch.hasOwnProperty('defaultValue')) return sch.defaultValue
-
   const type = getTypeOfSchemaFromSchema(sch)
+  if (sch.hasOwnProperty('defaultValue')) {
+    const defaultValue = sch.defaultValue
+    if (type === DynamicFormType.number) {
+      return util.parseInteger(defaultValue)
+    }
+
+    return defaultValue
+  }
+
   if (type === DynamicFormType.text && typeof sch === 'string') return sch
   if (type === DynamicFormType.number && typeof sch === 'number') return sch
 }

--- a/src/Schema/schema.test.js
+++ b/src/Schema/schema.test.js
@@ -219,7 +219,7 @@ test('Minimal nested form containing minimal sub-form returns recursively expand
   expect(schema(nestedForm)).toMatchObject(expectedExpandedForm)
 })
 
-test('Expanded repeatable form containing expanded sub-form returns recursively exapnded form', () => {
+test('Expanded repeatable form containing expanded sub-form returns recursively expanded form', () => {
   const repeatableForm = {
     key: {
       label: 'Users',
@@ -249,7 +249,7 @@ test('Expanded repeatable form containing expanded sub-form returns recursively 
   expect(schema(repeatableForm)).toMatchObject(expectedExpandedForm)
 })
 
-test('Expanded repeatable form containing minimal sub-form returns recursively exapnded form', () => {
+test('Expanded repeatable form containing minimal sub-form returns recursively expanded form', () => {
   const repeatableForm = {
     Users: {
       type: DynamicFormType.repeatable,
@@ -273,7 +273,7 @@ test('Expanded repeatable form containing minimal sub-form returns recursively e
   expect(schema(repeatableForm)).toMatchObject(expectedExpandedForm)
 })
 
-test('Minimal repeatable form containing expanded sub-form returns recursively exapnded form', () => {
+test('Minimal repeatable form containing expanded sub-form returns recursively expanded form', () => {
   const repeatableForm = {
     'Repeated Form': [
       {
@@ -301,7 +301,7 @@ test('Minimal repeatable form containing expanded sub-form returns recursively e
   expect(schema(repeatableForm)).toMatchObject(expectedExpandedForm)
 })
 
-test('Minimal repeatable form containing minimal sub-form returns recursively exapnded form', () => {
+test('Minimal repeatable form containing minimal sub-form returns recursively expanded form', () => {
   const repeatableForm = {
     Users: [{ 'Phone Number': Number }]
   }
@@ -322,9 +322,9 @@ test('Minimal repeatable form containing minimal sub-form returns recursively ex
   expect(schema(repeatableForm)).toMatchObject(expectedExpandedForm)
 })
 
-test('Minimal repeatable form containing minimal nested sub-form returns recursively exapnded form', () => {
+test('Minimal repeatable form containing minimal nested sub-form returns recursively expanded form', () => {
   const minimalForm = {
-    'Reapeated Form': [
+    'Repeated Form': [
       {
         'Nested Form': {
           stringy: 'stringy',
@@ -335,8 +335,8 @@ test('Minimal repeatable form containing minimal nested sub-form returns recursi
   }
 
   const expectedExpandedForm = {
-    'Reapeated Form': {
-      label: 'Reapeated Form',
+    'Repeated Form': {
+      label: 'Repeated Form',
       type: DynamicFormType.repeatable,
       schema: {
         'Nested Form': {
@@ -361,10 +361,10 @@ test('Minimal repeatable form containing minimal nested sub-form returns recursi
   expect(schema(minimalForm)).toMatchObject(expectedExpandedForm)
 })
 
-test('Minimal nested form containing minimal repeatable sub-form returns recursively exapnded form', () => {
+test('Minimal nested form containing minimal repeatable sub-form returns recursively expanded form', () => {
   const minimalForm = {
     'Nested Form': {
-      'Reapeated Form': [
+      'Repeated Form': [
         {
           stringy: String,
           numbery: 0
@@ -378,8 +378,8 @@ test('Minimal nested form containing minimal repeatable sub-form returns recursi
       label: 'Nested Form',
       type: DynamicFormType.nested,
       schema: {
-        'Reapeated Form': {
-          label: 'Reapeated Form',
+        'Repeated Form': {
+          label: 'Repeated Form',
           type: DynamicFormType.repeatable,
           schema: {
             stringy: {
@@ -398,4 +398,34 @@ test('Minimal nested form containing minimal repeatable sub-form returns recursi
   }
 
   expect(schema(minimalForm)).toMatchObject(expectedExpandedForm)
+})
+
+test('number: Default value of number form will be parsed', () => {
+  const numberForm = {
+    numberForm: {
+      label: 'Number Form',
+      type: DynamicFormType.number,
+      defaultValue: '0'
+    }
+  }
+
+  const parsedSchema = schema(numberForm).numberForm
+  expect(parsedSchema.defaultValue).toBe(0)
+})
+
+test('number: Default value of number form will be null if value is not parsable', () => {
+  const numberForm = {
+    numberForm: {
+      label: 'Number Form',
+      type: DynamicFormType.number,
+      defaultValue: 'xyz'
+    }
+  }
+
+  const parsedSchema = schema(numberForm).numberForm
+
+  expect(
+    Object.prototype.hasOwnProperty.call(parsedSchema, 'defaultValue')
+  ).toBeTruthy()
+  expect(parsedSchema.defaultValue).toBeNull()
 })

--- a/src/util/index.js
+++ b/src/util/index.js
@@ -14,7 +14,24 @@ const dispatchAsync = (func, timeToFireAfter = 0) => {
   }, timeToFireAfter)
 }
 
+// Returns if given paramter or parsed version of parameter is integer or not.
+const isInteger = (value) => {
+  return !isNaN(parseInt(value))
+}
+
+// Returns parsed integer or fallbackValue if not possible to parse.
+const parseInteger = (value, fallbackValue = null) => {
+  return isInteger(value) ? parseInt(value) : fallbackValue
+}
+
+const isUndefinedOrNull = (value) => {
+  return value === undefined || value === null
+}
+
 export default {
+  isUndefinedOrNull,
+  parseInteger,
+  isInteger,
   isFunction,
   uniqueKey,
   dispatchAsync


### PR DESCRIPTION
- `NumberForm` will have `integer` default value.
  - If `string` type is passed then it will be parsed to integer and if its not able to parse it fall back value will be give.
  - `NumberForm` will not change value to another type.

Fixes: #10 