### PR TITLE
✨ Add support for Sizeable button

### DIFF
--- a/src/DynamicForm/NodeForm.js
+++ b/src/DynamicForm/NodeForm.js
@@ -1,7 +1,8 @@
 import PropTypes from 'prop-types'
 import React, { useCallback, useRef } from 'react'
-import { DynamicFormType } from '../Schema'
+import { DynamicFormSize, DynamicFormType } from '../Schema'
 import util from '../util'
+import { buttonSizeFromSchemaSize } from './helper/styleHelper'
 import { NestedForm } from './NestedForm'
 import { RepeatableForm } from './RepeatableForm'
 import { ROLE_COMPONENT_NODE, ROLE_INPUT_NODE_DELETE } from './roles'
@@ -9,7 +10,13 @@ import { NumberForm, PasswordForm, StringForm } from './TextyForm'
 
 // TODO: Add tests
 // TODO: On hover add border
-const _NodeForm = ({ schema, atKey = null, onChange = () => {}, onDelete }) => {
+const _NodeForm = ({
+  schema,
+  atKey = null,
+  onChange = () => {},
+  onDelete,
+  deleteSize = DynamicFormSize.medium
+}) => {
   // Value container to store values.
   const valueContainer = useRef({})
   // Constant key prefix for children.
@@ -49,11 +56,18 @@ const _NodeForm = ({ schema, atKey = null, onChange = () => {}, onDelete }) => {
     )
   }
 
+  const deleteButtonSize = buttonSizeFromSchemaSize(deleteSize)
+  const className = {
+    card: 'card border-light',
+    body: 'card-body p-1 d-grid gap-1',
+    deleteButton: `btn btn-outline-danger w-20 ${deleteButtonSize}`
+  }
+
   let deleteButton
   if (util.isFunction(onDelete)) {
     deleteButton = (
       <button
-        className='btn btn-outline-danger w-20'
+        className={className.deleteButton}
         role={ROLE_INPUT_NODE_DELETE}
         onClick={() => onDelete({ key: atKey })}
       >
@@ -63,8 +77,8 @@ const _NodeForm = ({ schema, atKey = null, onChange = () => {}, onDelete }) => {
   }
 
   return (
-    <div role={ROLE_COMPONENT_NODE} className='card border-light'>
-      <div className='card-body p-1 d-grid gap-1'>
+    <div role={ROLE_COMPONENT_NODE} className={className.card}>
+      <div className={className.body}>
         {forms}
         {deleteButton}
       </div>
@@ -76,7 +90,8 @@ _NodeForm.propTypes = {
   schema: PropTypes.object.isRequired,
   atKey: PropTypes.string,
   onChange: PropTypes.func.isRequired,
-  onDelete: PropTypes.func
+  onDelete: PropTypes.func,
+  deleteSize: PropTypes.string // TODO: Check only for allowed values.
 }
 
 export const NodeForm = React.memo(_NodeForm)

--- a/src/DynamicForm/RepeatableForm.js
+++ b/src/DynamicForm/RepeatableForm.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types'
 import React, { useCallback, useRef, useState } from 'react'
 import util from '../util'
+import { buttonSizeFromSchemaSize } from './helper/styleHelper'
 import { NodeForm } from './NodeForm'
 import { ROLE_ADD_FORM, ROLE_LABEL_REPEATABLE } from './roles'
 
@@ -39,23 +40,33 @@ const _RepeatableForm = ({ schema, atKey = null, onChange }) => {
         schema={schema.schema}
         onChange={changeValueForKey}
         onDelete={removeFormWithValueForKey}
+        deleteSize={schema.size}
       />
     ])
   }
 
+  const addButtonStyle = buttonSizeFromSchemaSize(schema.size)
+  const className = {
+    card: 'card border-secondary',
+    cardHeader: 'card-header',
+    body: 'card-body p-1',
+    addButtonContainer: 'd-grid',
+    addButton: `btn btn-outline-secondary mx-1 w-auto ${addButtonStyle}`
+  }
+
   // TODO: Add icon to delete button
   return (
-    <div className='card border-secondary'>
+    <div className={className.card}>
       {schema.label && (
-        <div className='card-header' role={ROLE_LABEL_REPEATABLE}>
+        <div className={className.cardHeader} role={ROLE_LABEL_REPEATABLE}>
           {schema.label}
         </div>
       )}
-      <div className='card-body p-1'>
+      <div className={className.body}>
         {forms}
-        <div className='d-grid'>
+        <div className={className.addButtonContainer}>
           <button
-            className='btn btn-outline-secondary mx-1 w-auto'
+            className={className.addButton}
             role={ROLE_ADD_FORM}
             onClick={() => {
               addForm()

--- a/src/DynamicForm/TextyForm.js
+++ b/src/DynamicForm/TextyForm.js
@@ -50,6 +50,7 @@ export const PasswordForm = ({ schema, atKey = null, onChange }) => {
   )
 }
 
+// TODO: Add these functions in `styleHelper`
 const textyFormSizeFromSchemaSize = (schemaSize = DynamicFormSize.medium) => {
   if (schemaSize === DynamicFormSize.small) return 'form-control-sm'
   if (schemaSize === DynamicFormSize.large) return 'form-control-lg'

--- a/src/DynamicForm/__tests__/DynamicForm.test.js
+++ b/src/DynamicForm/__tests__/DynamicForm.test.js
@@ -1,9 +1,25 @@
 /* eslint-disable no-undef */
 import { fireEvent, render } from '@testing-library/react'
 import React from 'react'
-import { DynamicFormType } from '../../Schema'
+import { DynamicFormSize, DynamicFormType } from '../../Schema'
 import { DynamicForm } from '../index'
 import { ROLE_INPUT_DYNAMIC_SUBMIT, ROLE_INPUT_STRING } from '../roles'
+
+const GET_SIMPLE_DYNAMIC_FORM = ({
+  schema = {},
+  onChange = undefined,
+  onSubmit = undefined,
+  submitSize = undefined
+}) => {
+  return (
+    <DynamicForm
+      schema={schema}
+      onChange={onChange}
+      onSubmit={onSubmit}
+      submitSize={submitSize}
+    />
+  )
+}
 
 test('DynamicForm with correct props matches snapshot', () => {
   const component = render(
@@ -72,4 +88,51 @@ test('DynamicForm will call onSubmit correctly if submit is tapped', (done) => {
 
   const submitInput = component.getByRole(ROLE_INPUT_DYNAMIC_SUBMIT)
   fireEvent.click(submitInput)
+})
+
+describe('DynamicForm size is', () => {
+  test('small if small submit button size is passed', () => {
+    const component = render(
+      GET_SIMPLE_DYNAMIC_FORM({
+        onSubmit: () => {},
+        submitSize: DynamicFormSize.small
+      })
+    )
+
+    const input = component.getByRole(ROLE_INPUT_DYNAMIC_SUBMIT)
+    expect(input.classList).toContain('btn-sm')
+  })
+
+  test('medium if medium submit button size is passed', () => {
+    const component = render(
+      GET_SIMPLE_DYNAMIC_FORM({
+        onSubmit: () => {},
+        submitSize: DynamicFormSize.medium
+      })
+    )
+
+    const input = component.getByRole(ROLE_INPUT_DYNAMIC_SUBMIT)
+    expect(input.classList).toContain('btn-md')
+  })
+
+  test('medium if no submit button size is passed', () => {
+    const component = render(
+      GET_SIMPLE_DYNAMIC_FORM({ onSubmit: () => {}, submitSize: undefined })
+    )
+
+    const input = component.getByRole(ROLE_INPUT_DYNAMIC_SUBMIT)
+    expect(input.classList).toContain('btn-md')
+  })
+
+  test('large if large submit button size is passed', () => {
+    const component = render(
+      GET_SIMPLE_DYNAMIC_FORM({
+        onSubmit: () => {},
+        submitSize: DynamicFormSize.large
+      })
+    )
+
+    const input = component.getByRole(ROLE_INPUT_DYNAMIC_SUBMIT)
+    expect(input.classList).toContain('btn-lg')
+  })
 })

--- a/src/DynamicForm/__tests__/RepeatableForm.test.js
+++ b/src/DynamicForm/__tests__/RepeatableForm.test.js
@@ -3,7 +3,7 @@
 import { toBeInTheDocument } from '@testing-library/jest-dom'
 import { fireEvent, render } from '@testing-library/react'
 import React from 'react'
-import { DynamicFormType } from '../../Schema'
+import { DynamicFormSize, DynamicFormType } from '../../Schema'
 import { RepeatableForm } from '../RepeatableForm'
 import {
   ROLE_ADD_FORM,
@@ -17,13 +17,15 @@ import {
 const GET_SIMPLE_REPEATABLE_FORM = ({
   onChange = () => {},
   key = null,
-  label = 'Repeatable Form'
+  label = 'Repeatable Form',
+  size = DynamicFormSize.medium
 }) => {
   return (
     <RepeatableForm
       atKey={key}
       schema={{
-        label: label,
+        label,
+        size,
         schema: {
           stringForm: {
             label: 'String Form',
@@ -163,4 +165,64 @@ test('RepeatableForm with empty label will not have any label', () => {
   const component = render(GET_SIMPLE_REPEATABLE_FORM({ label: '' }))
 
   expect(component.queryByRole(ROLE_LABEL_REPEATABLE)).toBeNull()
+})
+
+describe('RepeatableForm size is', () => {
+  test('small if small schema size is passed', () => {
+    const component = render(
+      GET_SIMPLE_REPEATABLE_FORM({ size: DynamicFormSize.small })
+    )
+
+    // Add sub-form
+    const addFormInput = component.getByRole(ROLE_ADD_FORM)
+    fireEvent.click(addFormInput)
+
+    const deleteFormInput = component.getByRole(ROLE_INPUT_NODE_DELETE)
+
+    expect(addFormInput.classList).toContain('btn-sm')
+    expect(deleteFormInput.classList).toContain('btn-sm')
+  })
+
+  test('medium if medium schema size is passed', () => {
+    const component = render(
+      GET_SIMPLE_REPEATABLE_FORM({ size: DynamicFormSize.medium })
+    )
+
+    // Add sub-form
+    const addFormInput = component.getByRole(ROLE_ADD_FORM)
+    fireEvent.click(addFormInput)
+
+    const deleteFormInput = component.getByRole(ROLE_INPUT_NODE_DELETE)
+
+    expect(addFormInput.classList).toContain('btn-md')
+    expect(deleteFormInput.classList).toContain('btn-md')
+  })
+
+  test('medium if no schema size is passed', () => {
+    const component = render(GET_SIMPLE_REPEATABLE_FORM({ size: undefined }))
+
+    // Add sub-form
+    const addFormInput = component.getByRole(ROLE_ADD_FORM)
+    fireEvent.click(addFormInput)
+
+    const deleteFormInput = component.getByRole(ROLE_INPUT_NODE_DELETE)
+
+    expect(addFormInput.classList).toContain('btn-md')
+    expect(deleteFormInput.classList).toContain('btn-md')
+  })
+
+  test('large if large schema size is passed', () => {
+    const component = render(
+      GET_SIMPLE_REPEATABLE_FORM({ size: DynamicFormSize.large })
+    )
+
+    // Add sub-form
+    const addFormInput = component.getByRole(ROLE_ADD_FORM)
+    fireEvent.click(addFormInput)
+
+    const deleteFormInput = component.getByRole(ROLE_INPUT_NODE_DELETE)
+
+    expect(addFormInput.classList).toContain('btn-lg')
+    expect(deleteFormInput.classList).toContain('btn-lg')
+  })
 })

--- a/src/DynamicForm/__tests__/__snapshots__/DynamicForm.test.js.snap
+++ b/src/DynamicForm/__tests__/__snapshots__/DynamicForm.test.js.snap
@@ -34,7 +34,7 @@ Object {
           </div>
         </div>
         <button
-          class="btn btn-success mx-1 w-auto "
+          class="btn btn-success mx-1 w-auto btn-md"
           role="input-dynamic-submit"
         >
           Submit
@@ -72,7 +72,7 @@ Object {
         </div>
       </div>
       <button
-        class="btn btn-success mx-1 w-auto "
+        class="btn btn-success mx-1 w-auto btn-md"
         role="input-dynamic-submit"
       >
         Submit

--- a/src/DynamicForm/__tests__/__snapshots__/RepeatableForm.test.js.snap
+++ b/src/DynamicForm/__tests__/__snapshots__/RepeatableForm.test.js.snap
@@ -57,7 +57,7 @@ Object {
                 />
               </div>
               <button
-                class="btn btn-outline-danger w-20"
+                class="btn btn-outline-danger w-20 btn-md"
                 role="input-node-delete"
               >
                 Delete
@@ -104,7 +104,7 @@ Object {
                 />
               </div>
               <button
-                class="btn btn-outline-danger w-20"
+                class="btn btn-outline-danger w-20 btn-md"
                 role="input-node-delete"
               >
                 Delete
@@ -115,7 +115,7 @@ Object {
             class="d-grid"
           >
             <button
-              class="btn btn-outline-secondary mx-1 w-auto"
+              class="btn btn-outline-secondary mx-1 w-auto btn-md"
               role="role-add-form"
             >
               Add
@@ -178,7 +178,7 @@ Object {
               />
             </div>
             <button
-              class="btn btn-outline-danger w-20"
+              class="btn btn-outline-danger w-20 btn-md"
               role="input-node-delete"
             >
               Delete
@@ -225,7 +225,7 @@ Object {
               />
             </div>
             <button
-              class="btn btn-outline-danger w-20"
+              class="btn btn-outline-danger w-20 btn-md"
               role="input-node-delete"
             >
               Delete
@@ -236,7 +236,7 @@ Object {
           class="d-grid"
         >
           <button
-            class="btn btn-outline-secondary mx-1 w-auto"
+            class="btn btn-outline-secondary mx-1 w-auto btn-md"
             role="role-add-form"
           >
             Add
@@ -320,7 +320,7 @@ Object {
             class="d-grid"
           >
             <button
-              class="btn btn-outline-secondary mx-1 w-auto"
+              class="btn btn-outline-secondary mx-1 w-auto btn-md"
               role="role-add-form"
             >
               Add
@@ -347,7 +347,7 @@ Object {
           class="d-grid"
         >
           <button
-            class="btn btn-outline-secondary mx-1 w-auto"
+            class="btn btn-outline-secondary mx-1 w-auto btn-md"
             role="role-add-form"
           >
             Add

--- a/src/DynamicForm/helper/styleHelper.js
+++ b/src/DynamicForm/helper/styleHelper.js
@@ -1,0 +1,11 @@
+import { DynamicFormSize } from '../../Schema'
+
+const buttonSizeFromSchemaSize = (schemaSize) => {
+  if (schemaSize === DynamicFormSize.large) return 'btn-lg'
+  if (schemaSize === DynamicFormSize.medium) return 'btn-md'
+  if (schemaSize === DynamicFormSize.small) return 'btn-sm'
+
+  return 'btn-md'
+}
+
+export { buttonSizeFromSchemaSize }

--- a/src/DynamicForm/index.js
+++ b/src/DynamicForm/index.js
@@ -1,12 +1,19 @@
 import PropTypes from 'prop-types'
 import React, { useRef } from 'react'
+import { DynamicFormSize } from '../Schema'
 import util from '../util'
 import { NodeForm } from './NodeForm'
 import { ROLE_INPUT_DYNAMIC_SUBMIT } from './roles'
+import { buttonSizeFromSchemaSize } from './helper/styleHelper'
 
 // TODO: Add overall end to end test for all types of form
 // TODO: Add test for keys with large schema.
-export const DynamicForm = ({ schema, onChange = () => {}, onSubmit }) => {
+export const DynamicForm = ({
+  schema,
+  onChange = () => {},
+  onSubmit,
+  submitSize = DynamicFormSize.medium
+}) => {
   // Value container to store values.
   const valueContainer = useRef({})
   const changeValue = ({ newValue }) => {
@@ -20,11 +27,17 @@ export const DynamicForm = ({ schema, onChange = () => {}, onSubmit }) => {
     }
   }
 
-  let submitButton
+  const submitButtonSize = buttonSizeFromSchemaSize(submitSize)
+  const className = {
+    card: 'd-grid gap-1',
+    submitButton: `btn btn-success mx-1 w-auto ${submitButtonSize}`
+  }
+
+  let submitButton = null
   if (util.isFunction(onSubmit)) {
     submitButton = (
       <button
-        className='btn btn-success mx-1 w-auto '
+        className={className.submitButton}
         role={ROLE_INPUT_DYNAMIC_SUBMIT}
         onClick={() => {
           onSubmit({ ...valueContainer.current })
@@ -36,7 +49,7 @@ export const DynamicForm = ({ schema, onChange = () => {}, onSubmit }) => {
   }
 
   return (
-    <div className='d-grid gap-1'>
+    <div className={className.card}>
       <NodeForm schema={schema} onChange={changeValue} />
       {submitButton}
     </div>
@@ -46,5 +59,6 @@ export const DynamicForm = ({ schema, onChange = () => {}, onSubmit }) => {
 DynamicForm.propTypes = {
   schema: PropTypes.object.isRequired,
   onChange: PropTypes.func,
-  onSubmit: PropTypes.func
+  onSubmit: PropTypes.func,
+  submitSize: PropTypes.string // TODO: Check only for allowed values.
 }


### PR DESCRIPTION
Added support for sizeable buttons
1. Submit button <- will be controlled by new prop `submitSize`.
2. Add button <- will be controlled by size of associated repeatable form.
3. Delete button <- will be controlled by size of associated repeatable form.

COVERING_TEST: :heavy_check_mark:
FIXES: #31 